### PR TITLE
Check that email has been verified only if the key exists

### DIFF
--- a/fabric8a_auth/auth.py
+++ b/fabric8a_auth/auth.py
@@ -108,11 +108,11 @@ def login_required(view):
                 if not decoded:
                     lgr.error('Provide an Authorization token with the API request')
                     raise AuthError(401, 'Authentication failed - token missing')
-                elif "email_verified" not in decoded:
-                    raise AuthError(401, 'Can not retrieve the '
-                                         'email_verified property from the token')
-                elif decoded["email_verified"] in ('0', 'False', 'false'):
-                    raise AuthError(401, 'Email of the user has not been validated')
+                elif 'email_verified' in decoded:
+                    # only check if email is verified if the `email_verified` exists
+                    # TODO: revert once the token in Jenkins is updated
+                    if decoded['email_verified'] not in ('1', 'True', 'true'):
+                        raise AuthError(401, 'Email of the user has not been validated')
                 lgr.info('Successfully authenticated user {e} using JWT'.
                          format(e=decoded.get('email')))
             except jwt.ExpiredSignatureError:


### PR DESCRIPTION
Jenkins token in both prod-preview and prod environments doesn't have
the `email_verified` key. This patch should be reverted once the token
is updated.