### PR TITLE
QA script use directories.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ The first script checks the indentation, line lengths, variable names, whitespac
 script checks all documentation strings - its presense and format. Please fix any warnings and errors reported by these
 scripts.
 
+List of directories containing source code, that needs to be checked, are stored in a file `directories.txt`
+
 #### Code complexity measurement
 
 The scripts `measure-cyclomatic-complexity.sh` and `measure-maintainability-index.sh` are used to measure code complexity. These scripts can be run w/o any arguments:
@@ -54,6 +56,8 @@ Please note that due to Python's dynamic nature, static code analyzers are likel
 
 Because of this potential problems, only code detected with more than 90% of confidence is reported.
 
+List of directories containing source code, that needs to be checked, are stored in a file `directories.txt`
+
 #### Common issues detection
 
 The script `detect-common-errors.sh` can be used to detect common errors in the repository. This script can be run w/o any arguments:
@@ -63,6 +67,8 @@ The script `detect-common-errors.sh` can be used to detect common errors in the 
 ```
 
 Please note that only semantical problems are reported.
+
+List of directories containing source code, that needs to be checked, are stored in a file `directories.txt`
 
 #### Check for scripts written in BASH
 

--- a/check-docstyle.sh
+++ b/check-docstyle.sh
@@ -1,15 +1,21 @@
 #!/bin/bash
 
-directories="fabric8a_auth tests tools"
-separate_files="setup.py"
+IFS=$'\n'
+
+# list of directories with sources to check
+directories=$(cat directories.txt)
+
+# list of separate files to check
+separate_files=$(cat files.txt)
+
 pass=0
 fail=0
 
 function prepare_venv() {
-    VIRTUALENV=$(which virtualenv)
+    VIRTUALENV="$(which virtualenv)"
     if [ $? -eq 1 ]; then
         # python36 which is in CentOS does not have virtualenv binary
-        VIRTUALENV=$(which virtualenv-3)
+        VIRTUALENV="$(which virtualenv-3)"
     fi
 
     ${VIRTUALENV} -p python3 venv && source venv/bin/activate && python3 "$(which pip3)" install pydocstyle
@@ -58,7 +64,7 @@ done
 echo
 echo "----------------------------------------------------"
 echo "Checking documentation strings in the following files"
-echo $separate_files
+echo "$separate_files"
 echo "----------------------------------------------------"
 
 check_files "$separate_files"

--- a/detect-common-errors.sh
+++ b/detect-common-errors.sh
@@ -1,15 +1,21 @@
 #!/bin/bash
 
-directories="fabric8a_auth tests tools"
-separate_files="setup.py"
+IFS=$'\n'
+
+# list of directories with sources to check
+directories=$(cat directories.txt)
+
+# list of separate files to check
+separate_files=$(cat files.txt)
+
 pass=0
 fail=0
 
 function prepare_venv() {
-    VIRTUALENV=$(which virtualenv)
+    VIRTUALENV="$(which virtualenv)"
     if [ $? -eq 1 ]; then
         # python36 which is in CentOS does not have virtualenv binary
-        VIRTUALENV=$(which virtualenv-3)
+        VIRTUALENV="$(which virtualenv-3)"
     fi
 
     ${VIRTUALENV} -p python3 venv && source venv/bin/activate && python3 "$(which pip3)" install pyflakes

--- a/detect-dead-code.sh
+++ b/detect-dead-code.sh
@@ -1,15 +1,21 @@
 #!/bin/bash
 
-directories="fabric8a_auth tests tools"
-separate_files="setup.py"
+IFS=$'\n'
+
+# list of directories with sources to check
+directories=$(cat directories.txt)
+
+# list of separate files to check
+separate_files=$(cat files.txt)
+
 pass=0
 fail=0
 
 function prepare_venv() {
-    VIRTUALENV=$(which virtualenv)
+    VIRTUALENV="$(which virtualenv)"
     if [ $? -eq 1 ]; then
         # python36 which is in CentOS does not have virtualenv binary
-        VIRTUALENV=$(which virtualenv-3)
+        VIRTUALENV="$(which virtualenv-3)"
     fi
 
     ${VIRTUALENV} -p python3 venv && source venv/bin/activate && python3 "$(which pip3)" install vulture

--- a/directories.txt
+++ b/directories.txt
@@ -1,0 +1,3 @@
+fabric8a_auth
+tests
+tools

--- a/fabric8a_auth/errors.py
+++ b/fabric8a_auth/errors.py
@@ -10,6 +10,7 @@ class AuthError(Exception):
         @app.errorhandler(AuthError)
         def api_401_handler(err):
             return flask.jsonify(error=err.error), err.status_code
+
     """
 
     def __init__(self, status_code=401, error='authentication error'):

--- a/files.txt
+++ b/files.txt
@@ -1,0 +1,1 @@
+setup.py

--- a/run-linter.sh
+++ b/run-linter.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
-directories="fabric8a_auth tests tools"
-separate_files="setup.py"
+IFS=$'\n'
+
+# list of directories with sources to check
+directories=$(cat directories.txt)
+
+# list of separate files to check
+separate_files=$(cat files.txt)
+
 pass=0
 fail=0
 
@@ -47,14 +53,14 @@ done
 echo
 echo "----------------------------------------------------"
 echo "Running Python linter against selected files:"
-echo $separate_files
+echo "$separate_files"
 echo "----------------------------------------------------"
 
 # check for individual files
 for source in $separate_files
 do
-    echo $source
-    pycodestyle $source
+    echo "$source"
+    pycodestyle "$source"
     if [ $? -eq 0 ]
     then
         echo "    Pass"


### PR DESCRIPTION
This PR implements the first task in:
https://jira.coreos.com/browse/APPAI-516

Make all QA-related tools more effective and easier to use by developers

1. All QA-related scripts needs to be made unified by using external list of directories to check
2. All QA-related scripts needs to be moved into separate subdirectory
3. QA Dashboard should be updated to use the new scripts (as #1)

JIRA issue for the 1st task:
https://jira.coreos.com/browse/APPAI-481

Currently, several QA-related scripts have the 'source-directories' included in the script body. It would be nice to use separate and central configuration file for this.